### PR TITLE
refactor to use external config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ ENV \
   ARCH="i386,amd64" \
   MIRRORDIR="/debmirror" \
   DEBUGFILE="/tmp/debmirror-debug.log" \
-  METHOD="http"
+  METHOD="https"
 
 RUN \
-  apt-get update && apt-get install -o Dpkg::Options::=--force-confdef -y debmirror xz-utils && \
+  apt-get update && apt-get install -o Dpkg::Options::=--force-confdef -y debmirror xz-utils apt-transport-https && \
   chmod 0755 /debmirror_sync.sh && \
   mkdir -p ${MIRRORDIR} && \
   chmod 0777 ${MIRRORDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY files /
 
 ENV \
-  SOURCE_SRV=gb.archive.ubuntu.com \
-  SOURCE_DIR=/ubuntu \
-  DIST="trusty,trusty-security,trusty-updates,trusty-backports,trusty-proposed,xenial,xenial-security,xenial-updates,xenial-backports,xenial-proposed,bionic,bionic-security,bionic-updates,bionic-backports,bionic-proposed" \
-  SECTION="main,restricted,universe,multiverse" \
+  SOURCE_SRV=apt.puppetlabs.com \
+  SOURCE_DIR=/ \
+  DIST="trusty,xenial,bionic" \
+  SECTION="dependencies,main,PC1,puppet,puppet5,puppet6" \
   ARCH="i386,amd64" \
   MIRRORDIR="/debmirror" \
   DEBUGFILE="/tmp/debmirror-debug.log" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,21 @@
 FROM ubuntu:latest
 
-MAINTAINER James Eckersall james.eckersall@fasthosts.com
+MAINTAINER Matt Pays matt.pays@fasthosts.com
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY files /
 
 ENV \
-  SOURCE_SRV=apt.puppetlabs.com \
-  SOURCE_DIR=/ \
-  DIST="trusty,xenial,bionic" \
-  SECTION="dependencies,main,PC1,puppet,puppet5,puppet6" \
-  ARCH="i386,amd64" \
   MIRRORDIR="/debmirror" \
-  DEBUGFILE="/tmp/debmirror-debug.log" \
-  METHOD="https"
+  CONFDIR="/status" \
+  DEBUGFILE="debmirror-debug.log"
 
 RUN \
   apt-get update && apt-get install -o Dpkg::Options::=--force-confdef -y debmirror xz-utils apt-transport-https && \
   chmod 0755 /debmirror_sync.sh && \
+  mkdir -p ${CONFDIR} && \
+  chmod 0777 ${CONFDIR} && \
   mkdir -p ${MIRRORDIR} && \
   chmod 0777 ${MIRRORDIR}
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ubuntu-16-debmirror
 # debmirror
+
+
+refactored to use an external config file - 
+modify example.debmirror.conf and put in /config/path/debmirror.conf
+
+run with:
+
+docker run -v /repo/path:/debmirror -v /config/path:/status 1and1internet/debmirror
+

--- a/example.debmirror.conf
+++ b/example.debmirror.conf
@@ -1,0 +1,79 @@
+# Default config for debmirror
+
+# The config file is a perl script so take care to follow perl syntax.
+# Any setting in /etc/debmirror.conf overrides these defaults and
+# ~/.debmirror.conf overrides those again. Take only what you need.
+#
+# The syntax is the same as on the command line and variable names
+# loosely match option names. If you don't recognize something here
+# then just stick to the command line.
+#
+# Options specified on the command line override settings in the config
+# files.
+
+# Location of the local mirror (use with care)
+# $mirrordir="/path/to/mirrordir"
+
+# Output options
+$verbose=0;
+$progress=0;
+$debug=0;
+
+# Download options
+$host="archive.ubuntu.com";
+$user="anonymous";
+$passwd="anonymous@";
+$remoteroot="ubuntu";
+$download_method="ftp";
+@dists="precise";
+@sections="main,main/debian-installer,universe,restricted,multiverse";
+@arches="i386";
+# @ignores="";
+# @excludes="";
+# @includes="";
+# @excludes_deb_section="";
+# @limit_priority="";
+$omit_suite_symlinks=0;
+$skippackages=0;
+# @rsync_extra="doc,tools";
+$i18n=0;
+$getcontents=0;
+$do_source=1;
+$max_batch=0;
+
+# @di_dists="dists";
+# @di_archs="arches";
+
+# Save mirror state between runs; value sets validity of cache in days
+$state_cache_days=0;
+
+# Security/Sanity options
+$ignore_release_gpg=0;
+$ignore_release=0;
+$check_md5sums=0;
+$ignore_small_errors=0;
+
+# Cleanup
+$cleanup=0;
+$post_cleanup=1;
+
+# Locking options
+$timeout=300;
+
+# Rsync options
+$rsync_batch=200;
+$rsync_options="-aIL --partial";
+
+# FTP/HTTP options
+$passive=0;
+# $proxy="http://proxy:port/";
+
+# Dry run
+$dry_run=0;
+
+# Don't keep diff files but use them
+$diff_mode="use";
+
+# The config file must return true or perl complains.
+# Always copy this.
+1;

--- a/files/debmirror_sync.sh
+++ b/files/debmirror_sync.sh
@@ -1,1 +1,1 @@
-/usr/bin/debmirror -v -e http --method ${METHOD} -h ${SOURCE_SRV} -r ${SOURCE_DIR} --dist=${DIST} --section=${SECTION} --arch=${ARCH} --ignore-release-gpg --no-check-gpg ${MIRRORDIR} # >> ${DEBUGFILE} 2>&1
+/usr/bin/debmirror -v --config-file=${CONFDIR}/debmirror.conf ${MIRRORDIR} # >> ${CONFDIR}/${DEBUGFILE} 2>&1

--- a/puppet.example.debmirror.conf
+++ b/puppet.example.debmirror.conf
@@ -1,0 +1,79 @@
+# Default config for debmirror
+
+# The config file is a perl script so take care to follow perl syntax.
+# Any setting in /etc/debmirror.conf overrides these defaults and
+# ~/.debmirror.conf overrides those again. Take only what you need.
+#
+# The syntax is the same as on the command line and variable names
+# loosely match option names. If you don't recognize something here
+# then just stick to the command line.
+#
+# Options specified on the command line override settings in the config
+# files.
+
+# Location of the local mirror (use with care)
+#$mirrordir="/srv/mirrors/puppet";
+
+# Output options
+$verbose=1;
+$progress=0;
+$debug=0;
+
+# Download options
+$host="rsync.puppet.com";
+$user="anonymous";
+$passwd="anonymous@";
+$remoteroot="packages/apt";
+$download_method="rsync";
+@dists="trusty,xenial,bionic";
+@sections="dependencies,main,PC1,puppet,puppet5,puppet6";
+@arches="i386,amd64";
+# @ignores="";
+# @excludes="";
+# @includes="";
+# @excludes_deb_section="";
+# @limit_priority="";
+$omit_suite_symlinks=0;
+$skippackages=0;
+# @rsync_extra="doc,tools";
+$i18n=0;
+$getcontents=0;
+$do_source=1;
+$max_batch=0;
+
+# @di_dists="dists";
+# @di_archs="arches";
+
+# Save mirror state between runs; value sets validity of cache in days
+$state_cache_days=0;
+
+# Security/Sanity options
+$ignore_release_gpg=1;
+$ignore_release=0;
+$check_md5sums=0;
+$ignore_small_errors=0;
+
+# Cleanup
+$cleanup=0;
+$post_cleanup=1;
+
+# Locking options
+$timeout=300;
+
+# Rsync options
+$rsync_batch=200;
+$rsync_options="-aIL --partial";
+
+# FTP/HTTP options
+$passive=0;
+# $proxy="http://proxy:port/";
+
+# Dry run
+$dry_run=0;
+
+# Don't keep diff files but use them
+$diff_mode="use";
+
+# The config file must return true or perl complains.
+# Always copy this.
+1;

--- a/ubuntu.example.debmirror.conf
+++ b/ubuntu.example.debmirror.conf
@@ -1,0 +1,79 @@
+# Default config for debmirror
+
+# The config file is a perl script so take care to follow perl syntax.
+# Any setting in /etc/debmirror.conf overrides these defaults and
+# ~/.debmirror.conf overrides those again. Take only what you need.
+#
+# The syntax is the same as on the command line and variable names
+# loosely match option names. If you don't recognize something here
+# then just stick to the command line.
+#
+# Options specified on the command line override settings in the config
+# files.
+
+# Location of the local mirror (use with care)
+# $mirrordir="/path/to/mirrordir"
+
+# Output options
+$verbose=0;
+$progress=0;
+$debug=0;
+
+# Download options
+$host="gb.archive.ubuntu.com";
+$user="anonymous";
+$passwd="anonymous@";
+$remoteroot="ubuntu";
+$download_method="ftp";
+@dists="trusty,xenial,bionic";
+@sections="main,main/debian-installer,universe,restricted,multiverse";
+@arches="i386,amd64";
+# @ignores="";
+# @excludes="";
+# @includes="";
+# @excludes_deb_section="";
+# @limit_priority="";
+$omit_suite_symlinks=0;
+$skippackages=0;
+# @rsync_extra="doc,tools";
+$i18n=0;
+$getcontents=0;
+$do_source=1;
+$max_batch=0;
+
+# @di_dists="dists";
+# @di_archs="arches";
+
+# Save mirror state between runs; value sets validity of cache in days
+$state_cache_days=0;
+
+# Security/Sanity options
+$ignore_release_gpg=0;
+$ignore_release=0;
+$check_md5sums=0;
+$ignore_small_errors=0;
+
+# Cleanup
+$cleanup=0;
+$post_cleanup=1;
+
+# Locking options
+$timeout=300;
+
+# Rsync options
+$rsync_batch=200;
+$rsync_options="-aIL --partial";
+
+# FTP/HTTP options
+$passive=0;
+# $proxy="http://proxy:port/";
+
+# Dry run
+$dry_run=0;
+
+# Don't keep diff files but use them
+$diff_mode="use";
+
+# The config file must return true or perl complains.
+# Always copy this.
+1;

--- a/ubuntu.example.debmirror.conf
+++ b/ubuntu.example.debmirror.conf
@@ -15,7 +15,7 @@
 # $mirrordir="/path/to/mirrordir"
 
 # Output options
-$verbose=0;
+$verbose=1;
 $progress=0;
 $debug=0;
 
@@ -24,9 +24,9 @@ $host="gb.archive.ubuntu.com";
 $user="anonymous";
 $passwd="anonymous@";
 $remoteroot="ubuntu";
-$download_method="ftp";
-@dists="trusty,xenial,bionic";
-@sections="main,main/debian-installer,universe,restricted,multiverse";
+$download_method="http";
+@dists="trusty,trusty-security,trusty-updates,trusty-backports,trusty-proposed,xenial,xenial-security,xenial-updates,xenial-backports,xenial-proposed,bionic,bionic-security,bionic-updates,bionic-backports,bionic-proposed";
+@sections="main,universe,restricted,multiverse";
 @arches="i386,amd64";
 # @ignores="";
 # @excludes="";


### PR DESCRIPTION
changes to debmirror docker image to allow it to sync multiple apt-based repositories